### PR TITLE
Added password variable to keyvault example

### DIFF
--- a/components/keyvault/variables.tf
+++ b/components/keyvault/variables.tf
@@ -29,6 +29,11 @@ variable "service_principal_object_id" {
   description = "The service principal object id"
 }
 
+variable "password" {
+  type        = "string"
+  description = "The service principal password/client secret"
+}
+
 variable "passwordy_mcssl_passwordface" {
   type        = "string"
   description = "The auto prompt for ssl certificate password"


### PR DESCRIPTION
The password variable needs to be added to avoid the error:

Error: Value for undeclared variable

A variable named "password" was assigned on the command line, but the root
module does not declare a variable of that name. To use this value, add a
"variable" block to the configuration.